### PR TITLE
Event timing

### DIFF
--- a/exp-player/addon/components/exp-lookit-dialogue-page/component.js
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/component.js
@@ -646,37 +646,8 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         return fullAsset;
     },
 
-    // TODO: should this be moved to the recording mixin?
-    sendTimeEvent(name, opts = {}) {
-        var streamTime = this.get('recorder') ? this.get('recorder').getTime() : null;
-        Ember.merge(opts, {
-            streamTime: streamTime,
-            videoId: this.get('videoId')
-        });
-        this.send('setTimeEvent', `exp-lookit-dialogue-page:${name}`, opts);
-    },
-
-    // TODO: should the events here be moved to the fullscreen mixin?
-    onFullscreen() {
-        if (this.get('isDestroyed')) {
-            return;
-        }
-        this._super(...arguments);
-        if (!this.checkFullscreen()) {
-            /**
-             * Upon detecting change out of fullscreen mode
-             *
-             * @event leftFullscreen
-            */
-            this.sendTimeEvent('leftFullscreen');
-        } else {
-            /**
-             * Upon detecting change to fullscreen mode
-             *
-             * @event enteredFullscreen
-            */
-            this.sendTimeEvent('enteredFullscreen');
-        }
+    makeTimeEvent(eventName, extra) {
+        return this._super(`exp-lookit-dialogue-page:${eventName}`, extra);
     },
 
     didInsertElement() {

--- a/exp-player/addon/components/exp-lookit-dialogue-page/component.js
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/component.js
@@ -713,7 +713,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
 
                 // Add event handlers on top of what the VideoRecordMixin normally does - TODO: would ideally extend functionality of mixin handlers rather than replacing
                 const recorder = this.get('recorder');
-                recorder.on('onCamAccess', () => {
+                recorder.on('onCamAccess', (hasAccess) => {
                     this.send('setTimeEvent', 'hasCamAccess', {
                         hasCamAccess: hasAccess
                     });

--- a/exp-player/addon/components/exp-lookit-dialogue-page/component.js
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/component.js
@@ -708,17 +708,22 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                  */
                 installPromise.then(() => {
                     this.send('setTimeEvent', 'recorderReady');
-                    this.set('recordingIsReady', true);
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 
-                // Add event handlers on top of what the VideoRecordMixin normally does
+                // Add event handlers on top of what the VideoRecordMixin normally does - TODO: would ideally extend functionality of mixin handlers rather than replacing
                 const recorder = this.get('recorder');
                 recorder.on('onCamAccess', () => {
+                    this.send('setTimeEvent', 'hasCamAccess', {
+                        hasCamAccess: hasAccess
+                    });
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 
                 recorder.on('onConnectionStatus', () => {
+                    this.send('setTimeEvent', 'videoStreamConnection', {
+                        status: status
+                    });
                     this.notifyPropertyChange('readyToStartAudio');
                 });
             }

--- a/exp-player/addon/components/exp-lookit-dialogue-page/component.js
+++ b/exp-player/addon/components/exp-lookit-dialogue-page/component.js
@@ -518,7 +518,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                  * @event clickSpeaker
                  * @param {String} imageId
                  */
-                this.sendTimeEvent('clickSpeaker', {
+                this.send('setTimeEvent', 'clickSpeaker', {
                     imageId: imageId
                 });
 
@@ -545,7 +545,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                      * @event startSpeakerAudio
                      * @param {String} imageId
                      */
-                    this.sendTimeEvent('startSpeakerAudio', {
+                    this.send('setTimeEvent', 'startSpeakerAudio', {
                         imageId: imageId
                     });
                 }
@@ -560,7 +560,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
              * @event completeSpeakerAudio
              * @param {String} imageId
              */
-            this.sendTimeEvent('completeSpeakerAudio', {
+            this.send('setTimeEvent', 'completeSpeakerAudio', {
                 imageId: imageId
             });
 
@@ -581,15 +581,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         },
 
         next() {
-            if (this.get('recorder')) {
-                /**
-                 * Just before stopping webcam video capture
-                 *
-                 * @event stoppingCapture
-                 */
-                this.sendTimeEvent('stoppingCapture');
-                this.get('recorder').stop();
-            }
+            this.stopRecorder();
             this._super(...arguments);
         },
 
@@ -606,7 +598,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                      *
                      * @event completeMainAudio
                      */
-                    this.sendTimeEvent('completeMainAudio');
+                    this.send('setTimeEvent', 'completeMainAudio');
                     this.set('completedAudio', true);
                     this.notifyPropertyChange('readyToProceed');
                 }
@@ -705,44 +697,30 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         // start audio once recording is ready. Otherwise, start audio right
         // away.
         if (_this.get('doRecording')) {
-            if (_this.get('experiment') && _this.get('id') && _this.get('session')) {
-                let recorder = _this.get('videoRecorder').start(_this.get('videoId'), _this.$('#videoRecorder'), {
+            if (this.get('experiment') && this.get('id') && this.get('session')) {
+                const installPromise = this.setupRecorder(this.$('#videoRecorder'), true, {
                     hidden: true
                 });
-                recorder.install({
-                    record: true
-                }).then(() => {
-                    _this.sendTimeEvent('recorderReady');
-                    _this.set('recordingIsReady', true);
-                    _this.notifyPropertyChange('readyToStartAudio');
-                });
-                // TODO: move handlers that just record events to the VideoRecord mixin?
                 /**
-                 * When recorder detects a change in camera access
+                 * When video recorder has been installed
                  *
-                 * @event onCamAccess
-                 * @param {Boolean} hasCamAccess
+                 * @event recorderReady
                  */
-                recorder.on('onCamAccess', (hasAccess) => {
-                    _this.sendTimeEvent('hasCamAccess', {
-                        hasCamAccess: hasAccess
-                    });
-                    _this.notifyPropertyChange('readyToStartAudio');
+                installPromise.then(() => {
+                    this.send('setTimeEvent', 'recorderReady');
+                    this.set('recordingIsReady', true);
+                    this.notifyPropertyChange('readyToStartAudio');
                 });
-                /**
-                 * When recorder detects a change in video stream connection status
-                 *
-                 * @event videoStreamConnection
-                 * @param {String} status status of video stream connection, e.g.
-                 * 'NetConnection.Connect.Success' if successful
-                 */
-                recorder.on('onConnectionStatus', (status) => {
-                    _this.sendTimeEvent('videoStreamConnection', {
-                        status: status
-                    });
-                    _this.notifyPropertyChange('readyToStartAudio');
+
+                // Add event handlers on top of what the VideoRecordMixin normally does
+                const recorder = this.get('recorder');
+                recorder.on('onCamAccess', () => {
+                    this.notifyPropertyChange('readyToStartAudio');
                 });
-                _this.set('recorder', recorder);
+
+                recorder.on('onConnectionStatus', () => {
+                    this.notifyPropertyChange('readyToStartAudio');
+                });
             }
         } else {
             _this.send('playNextAudioSegment');
@@ -751,12 +729,13 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
     },
 
     willDestroyElement() {
-        this.sendTimeEvent('destroyingElement');
+        this.send('setTimeEvent', 'destroyingElement');
 
         // Whenever the component is destroyed, make sure that event handlers are removed and video recorder is stopped
-        if (this.get('recorder')) {
-            this.get('recorder').hide(); // Hide the webcam config screen
-            this.get('recorder').stop();
+        const recorder = this.get('recorder');
+        if (recorder) {
+            recorder.hide(); // Hide the webcam config screen
+            this.stopRecorder();
         }
 
         this._super(...arguments);

--- a/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
+++ b/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
@@ -648,28 +648,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         }
     },
 
-    onFullscreen() {
-        if (this.get('isDestroyed')) {
-            return;
-        }
-        this._super(...arguments);
-        if (!this.checkFullscreen()) {
-            /**
-             * When change to non-fullscreen is detected
-             *
-             * @event leftFullscreen
-             */
-            this.send('setTimeEvent', 'leftFullscreen');
-        } else {
-            /**
-             * When change to fullscreen is detected
-             *
-             * @event enteredFullscreen
-             */
-            this.send('setTimeEvent', 'enteredFullscreen');
-        }
-    },
-
     getRandomElement(arr) {
         return arr[Math.floor(Math.random() * arr.length)];
     },

--- a/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
+++ b/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
@@ -891,7 +891,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                  * @event recorderReady
                  */
                 this.send('setTimeEvent', 'recorderReady');
-                this.set('recordingIsReady', true);
             });
         }
     },

--- a/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
+++ b/exp-player/addon/components/exp-lookit-geometry-alternation/component.js
@@ -518,6 +518,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
     makeTimeEvent(eventName, extra) {
         return this._super(`exp-alternation:${eventName}`, extra);
     },
+
     actions: {
         // When intro audio is complete
         endAudio() {
@@ -795,12 +796,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
 
             // Currently paused: RESUME
             if (wasPaused) {
-
-                /**
-                 * When unpausing study, immediately before request to resume webcam recording
-                 *
-                 * @event unpauseVideo
-                 */
                 try {
                     this.resumeRecorder();
                 } catch (_) {
@@ -810,11 +805,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                 this.set('isPaused', false);
             } else { // Not currently paused: PAUSE
                 window.clearTimeout(this.get('introTimer'));
-                /**
-                 * When pausing study, immediately before request to pause webcam recording
-                 *
-                 * @event pauseVideo
-                 */
                 this.pauseRecorder(true);
                 if (this.checkFullscreen()) {
                     $('#player-pause-audio')[0].play();
@@ -912,17 +902,16 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         this.startIntro();
 
         if (this.get('experiment') && this.get('id') && this.get('session')) {
-            /**
-             * When recorder detects a change in camera access
-             *
-             * @event onCamAccess
-             * @param {Boolean} hasCamAccess
-             */
 
             const installPromise = this.setupRecorder(this.$('#videoRecorder'), true, {
                 hidden: true
             });
             installPromise.then(() => {
+                /**
+                 * When video recorder has been installed
+                 *
+                 * @event recorderReady
+                 */
                 this.send('setTimeEvent', 'recorderReady');
                 this.set('recordingIsReady', true);
             });

--- a/exp-player/addon/components/exp-lookit-preferential-looking/component.js
+++ b/exp-player/addon/components/exp-lookit-preferential-looking/component.js
@@ -1009,7 +1009,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                  * @event recorderReady
                  */
                 this.send('setTimeEvent', 'recorderReady');
-                this.set('recordingIsReady', true);
             });
         }
     },

--- a/exp-player/addon/components/exp-lookit-preferential-looking/component.js
+++ b/exp-player/addon/components/exp-lookit-preferential-looking/component.js
@@ -723,11 +723,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         },
 
         next() {
-            /**
-             * Just before stopping webcam video capture
-             *
-             * @event stoppingCapture
-             */
             this.stopRecorder();
             this._super(...arguments);
         }
@@ -946,11 +941,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                     this.currentTime = 0;
                 });
 
-                /**
-                 * When unpausing study, immediately before request to resume webcam recording
-                 *
-                 * @event unpauseVideo
-                 */
                 try {
                     this.resumeRecorder();
                 } catch (_) {
@@ -979,11 +969,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                 window.clearTimeout(this.get('stimTimer'));
                 window.clearTimeout(this.get('calTimer'));
 
-                /**
-                 * When pausing study, immediately before request to pause webcam recording
-                 *
-                 * @event pauseVideo
-                 */
                 this.pauseRecorder(true);
 
                 if (this.checkFullscreen()) {
@@ -1027,12 +1012,16 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         $(document).on('keyup.pauser', function(e) {_this.handleSpace(e, _this);});
         this.startIntro();
 
-        // TODO: move handlers that just record events to the VideoRecord mixin?
         if (this.get('experiment') && this.get('id') && this.get('session')) {
             const installPromise = this.setupRecorder(this.$('#videoRecorder'), true, {
                 hidden: true
             });
             installPromise.then(() => {
+                /**
+                 * When video recorder has been installed
+                 *
+                 * @event recorderReady
+                 */
                 this.send('setTimeEvent', 'recorderReady');
                 this.set('recordingIsReady', true);
             });

--- a/exp-player/addon/components/exp-lookit-preferential-looking/component.js
+++ b/exp-player/addon/components/exp-lookit-preferential-looking/component.js
@@ -888,29 +888,15 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         return this._super(`exp-lookit-preferential-looking:${eventName}`, extra);
     },
 
-    // TODO: should the events here be moved to the fullscreen mixin?
     onFullscreen() {
         if (this.get('isDestroyed')) {
             return;
         }
         this._super(...arguments);
         if (!this.checkFullscreen()) {
-            /**
-             * Upon detecting change out of fullscreen mode
-             *
-             * @event leftFullscreen
-            */
-            this.send('setTimeEvent', 'leftFullscreen');
             if (!(this.get('isPaused')) && (this.get('currentSegment') !== 'finalaudio')) {
                 this.pauseStudy();
             }
-        } else {
-            /**
-             * Upon detecting change to fullscreen mode
-             *
-             * @event enteredFullscreen
-            */
-            this.send('setTimeEvent', 'enteredFullscreen');
         }
     },
 

--- a/exp-player/addon/components/exp-lookit-story-page/component.js
+++ b/exp-player/addon/components/exp-lookit-story-page/component.js
@@ -375,11 +375,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         },
 
         next() {
-            /**
-             * Just before stopping webcam video capture
-             *
-             * @event stoppingCapture
-             */
             this.stopRecorder();
             this._super(...arguments);
         },
@@ -483,31 +478,23 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                 const installPromise = this.setupRecorder(this.$('#videoRecorder'), true, {
                     hidden: true
                 });
+                /**
+                 * When video recorder has been installed
+                 *
+                 * @event recorderReady
+                 */
                 installPromise.then(() => {
                     this.send('setTimeEvent', 'recorderReady');
                     this.set('recordingIsReady', true);
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 
-                // TODO: move handlers that just record events to the VideoRecord mixin?
-                /**
-                 * When recorder detects a change in camera access
-                 *
-                 * @event onCamAccess
-                 * @param {Boolean} hasCamAccess
-                 */
-                // Add event handler on top of what the VideoRecordMixin normally does
+                // Add event handlers on top of what the VideoRecordMixin normally does
                 const recorder = this.get('recorder');
                 recorder.on('onCamAccess', () => {
                     this.notifyPropertyChange('readyToStartAudio');
                 });
-                /**
-                 * When recorder detects a change in video stream connection status
-                 *
-                 * @event videoStreamConnection
-                 * @param {String} status status of video stream connection, e.g.
-                 * 'NetConnection.Connect.Success' if successful
-                 */
+
                 recorder.on('onConnectionStatus', () => {
                     this.notifyPropertyChange('readyToStartAudio');
                 });

--- a/exp-player/addon/components/exp-lookit-story-page/component.js
+++ b/exp-player/addon/components/exp-lookit-story-page/component.js
@@ -429,29 +429,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
         return this._super(`exp-lookit-story-page:${eventName}`, extra);
     },
 
-    // TODO: should the events here be moved to the fullscreen mixin?
-    onFullscreen() {
-        if (this.get('isDestroyed')) {
-            return;
-        }
-        this._super(...arguments);
-        if (!this.checkFullscreen()) {
-            /**
-             * Upon detecting change out of fullscreen mode
-             *
-             * @event leftFullscreen
-            */
-            this.send('setTimeEvent', 'leftFullscreen');
-        } else {
-            /**
-             * Upon detecting change to fullscreen mode
-             *
-             * @event enteredFullscreen
-            */
-            this.send('setTimeEvent', 'enteredFullscreen');
-        }
-    },
-
     didInsertElement() {
         this._super(...arguments);
 

--- a/exp-player/addon/components/exp-lookit-story-page/component.js
+++ b/exp-player/addon/components/exp-lookit-story-page/component.js
@@ -467,7 +467,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
 
                 // Add event handlers on top of what the VideoRecordMixin normally does - TODO: would ideally extend functionality of mixin handlers rather than replacing
                 const recorder = this.get('recorder');
-                recorder.on('onCamAccess', () => {
+                recorder.on('onCamAccess', (hasAccess) => {
                     this.send('setTimeEvent', 'hasCamAccess', {
                         hasCamAccess: hasAccess
                     });

--- a/exp-player/addon/components/exp-lookit-story-page/component.js
+++ b/exp-player/addon/components/exp-lookit-story-page/component.js
@@ -462,7 +462,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                  */
                 installPromise.then(() => {
                     this.send('setTimeEvent', 'recorderReady');
-                    this.set('recordingIsReady', true);
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 

--- a/exp-player/addon/components/exp-lookit-story-page/component.js
+++ b/exp-player/addon/components/exp-lookit-story-page/component.js
@@ -466,13 +466,19 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, VideoRecord,  {
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 
-                // Add event handlers on top of what the VideoRecordMixin normally does
+                // Add event handlers on top of what the VideoRecordMixin normally does - TODO: would ideally extend functionality of mixin handlers rather than replacing
                 const recorder = this.get('recorder');
                 recorder.on('onCamAccess', () => {
+                    this.send('setTimeEvent', 'hasCamAccess', {
+                        hasCamAccess: hasAccess
+                    });
                     this.notifyPropertyChange('readyToStartAudio');
                 });
 
                 recorder.on('onConnectionStatus', () => {
+                    this.send('setTimeEvent', 'videoStreamConnection', {
+                        status: status
+                    });
                     this.notifyPropertyChange('readyToStartAudio');
                 });
             }

--- a/exp-player/addon/components/exp-video-physics/component.js
+++ b/exp-player/addon/components/exp-video-physics/component.js
@@ -37,7 +37,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
     fsButtonID: 'fsButton',
     videoRecorder: Ember.inject.service(),
     recorder: null,
-    recordingIsReady: false,
     warning: null,
     hasCamAccess: Ember.computed.alias('recorder.hasCamAccess'),
     videoUploadConnected: Ember.computed.alias('recorder.connected'),
@@ -470,7 +469,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
                  * @event recorderReady
                  */
                 this.send('setTimeEvent', 'recorderReady');
-                this.set('recordingIsReady', true);
             });
         }
         this.send('showFullscreen');

--- a/exp-player/addon/components/exp-video-physics/component.js
+++ b/exp-player/addon/components/exp-video-physics/component.js
@@ -449,12 +449,11 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
 
     didInsertElement() {
         this._super(...arguments);
-        $(document).on('keyup', (e) => {
+        $(document).on('keyup.pauser', (e) => {
             if (this.checkFullscreen()) {
-                if (e.which === 32) { // space
+                if (e.which === 32) { // space: pause/unpause study
                     this.pauseStudy();
                 } else if (e.which === 112) { // F1: exit the study early
-                    // FIXME: This binding does not seem to fire, likely because it is removed in willDestroy, called when exp-player advances to a new frame
                     this.stopRecorder();
                 }
             }
@@ -465,6 +464,11 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
                 hidden: true
             });
             installPromise.then(() => {
+                /**
+                 * When video recorder has been installed
+                 *
+                 * @event recorderReady
+                 */
                 this.send('setTimeEvent', 'recorderReady');
                 this.set('recordingIsReady', true);
             });
@@ -481,7 +485,6 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
 
         this.send('setTimeEvent', 'destroyingElement');
         this._super(...arguments);
-        // Todo: make removal of event listener more specific (in case a frame comes between the video and the exit survey)
-        $(document).off('keyup');
+        $(document).off('keyup.pauser');
     }
 });

--- a/exp-player/addon/components/exp-video-physics/component.js
+++ b/exp-player/addon/components/exp-video-physics/component.js
@@ -286,6 +286,7 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
                 });
             }
         },
+
         removeWarning() {
             this.set('showVideoWarning', false);
             this.get('recorder').hide();

--- a/exp-player/addon/components/exp-video-physics/component.js
+++ b/exp-player/addon/components/exp-video-physics/component.js
@@ -256,18 +256,18 @@ export default ExpFrameBaseUnsafeComponent.extend(FullScreen, MediaReload, Video
         }
         this._super(...arguments);
         if (!this.checkFullscreen()) {
-            this.send('setTimeEvent', 'leftFullscreen');
             if (!this.get('isPaused')) {
                 this.pauseStudy();
             }
-        } else {
-            this.send('setTimeEvent', 'enteredFullscreen');
         }
     },
+
     makeTimeEvent(eventName, extra) {
         return this._super(`exp-physics:${eventName}`, extra);
     },
+
     actions: {
+
         showWarning() {
             if (!this.get('showVideoWarning')) {
                 this.set('showVideoWarning', true);

--- a/exp-player/addon/components/exp-video-preview/component.js
+++ b/exp-player/addon/components/exp-video-preview/component.js
@@ -63,7 +63,7 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
         return this.get('videos')[this.get('videoIndex')];
     }),
     makeTimeEvent(eventName, extra) {
-        return this._super(`exp-physics:${eventName}`, extra);
+        return this._super(`exp-video-preview:${eventName}`, extra);
     },
     actions: {
         accept() {

--- a/exp-player/addon/components/exp-video-preview/component.js
+++ b/exp-player/addon/components/exp-video-preview/component.js
@@ -46,7 +46,6 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
 
     videoRecorder: Ember.inject.service(),
     recorder: null,
-    recordingIsReady: false,
     warning: null,
     hasCamAccess: Ember.computed.alias('recorder.hasCamAccess'),
     videoUploadConnected: Ember.computed.alias('recorder.connected'),
@@ -74,7 +73,6 @@ export default ExpFrameBaseComponent.extend(MediaReload, VideoRecord, {
                 });
                 installPromise.then(() => {
                     this.send('setTimeEvent', 'recorderReady');
-                    this.set('recordingIsReady', true);
                 });
             }
         },

--- a/exp-player/addon/mixins/full-screen.js
+++ b/exp-player/addon/mixins/full-screen.js
@@ -65,17 +65,27 @@ export default Ember.Mixin.create({
 
         var $button = $(`#${this.get('fsButtonID')}`);
         if (isFS) {
-            // alert('went fs');
             $element.addClass('player-fullscreen');
             if (this.displayFullscreen && this.fsButtonID) {
                 $button.hide();
             }
+            /**
+             * Upon detecting change to fullscreen mode
+             *
+             * @event enteredFullscreen
+            */
+            this.send('setTimeEvent', 'enteredFullscreen');
         } else {
-            //alert('left fs');
             $element.removeClass('player-fullscreen');
             if (this.displayFullscreen && this.fsButtonID) {
                 $button.show();
             }
+            /**
+             * Upon detecting change out of fullscreen mode
+             *
+             * @event leftFullscreen
+            */
+            this.send('setTimeEvent', 'leftFullscreen');
         }
     },
 

--- a/exp-player/addon/mixins/video-record.js
+++ b/exp-player/addon/mixins/video-record.js
@@ -12,22 +12,35 @@ import Ember from 'ember';
  */
 
 /**
+ * When recorder detects a change in camera access
+ *
  * @event hasCamAccess
+ * @param {Boolean} hasCamAccess
  */
 
 /**
+ * When recorder detects a change in video stream connection status
+ *
  * @event videoStreamConnection
+ * @param {String} status status of video stream connection, e.g.
+ * 'NetConnection.Connect.Success' if successful
  */
 
 /**
+ * When pausing study, immediately before request to pause webcam recording
+ *
  * @event pauseVideo
  */
 
 /**
+ * When unpausing study, immediately before request to resume webcam recording
+ *
  * @event unpauseVideo
  */
 
 /**
+ * Just before stopping webcam video capture
+ *
  * @event stoppingCapture
  */
 


### PR DESCRIPTION
Checking over additions to generalize event recording for frames extending VideoRecord mixin:

- added similar generalized events for fullscreen
- updated exp-lookit-dialogue-page in line with other frames

Testing notes: 
Event recording tested on each of the five current studies (physics, geometry, polcon, labels&concepts, ingroupobligations - corresponding to exp-video-physics, exp-lookit-geometry-alternation, exp-lookit-dialogue-page, exp-lookit-preferential-looking, exp-lookit-story-page) by making sure that enteredFullscreen, leftFullscreen were recorded when they happened and that videoStreamConnection events were recorded for each video recording frame (hasCamAccess is recorded more sporadically--maybe sometimes it's already true). 

The only outstanding issue to address before merging is that 'recorderReady' events are NEVER recorded. To be fair, I don't think they ever were! But this is a bit troubling in terms of how we'd expect the installPromise to work.